### PR TITLE
Fix: Update game logic and ARIA announcements

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -87,13 +87,10 @@ export default function App() {
       const currentTrialData = sequence[currentSequenceIndex];
       if (currentTrialData) {
         playLetter(currentTrialData.letter);
-        const isFiller = currentSequenceIndex < FILLERS;
-        if (!isFiller) {
-          const posLabel = positionLabels[currentTrialData.position] || `Position ${currentTrialData.position + 1}`;
-          updateAnnouncer('active-cell-announcer', `Cell ${posLabel}. Letter ${currentTrialData.letter}.`);
-        } else {
-          updateAnnouncer('active-cell-announcer', `Get ready. Letter ${currentTrialData.letter}.`);
-        }
+        // const isFiller = currentSequenceIndex < FILLERS; // This variable is no longer strictly needed for the announcer text
+        const posLabel = positionLabels[currentTrialData.position] || `Position ${currentTrialData.position + 1}`;
+        // Always announce position and letter for active trials
+        updateAnnouncer('active-cell-announcer', `Cell ${posLabel}. Letter ${currentTrialData.letter}.`);
       } else {
         updateAnnouncer('active-cell-announcer', '');
       }

--- a/src/utils/evaluator.js
+++ b/src/utils/evaluator.js
@@ -9,19 +9,29 @@ export function evaluateResponses({ trials, responses, n }) {
     dualTotal = 0;
 
   trials.forEach((t, i) => {
-    if (i < n) return; // non‑scorable
+    if (i < n) return; // non-scorable
 
-    const isVisMatch = t.position === trials[i - n].position;
-    const isAudMatch = t.letter === trials[i - n].letter;
+    const isVisMatchTarget = t.position === trials[i - n].position;
+    const isAudMatchTarget = t.letter === trials[i - n].letter;
+    const userResponse = responses.get(i) || { vis: false, aud: false };
 
-    if (isVisMatch && isAudMatch) dualTotal++;
-    else if (isVisMatch) visualTotal++;
-    else if (isAudMatch) audioTotal++;
-
-    const r = responses.get(i) || { vis: false, aud: false };
-    if (isVisMatch && r.vis) visualHits++;
-    if (isAudMatch && r.aud) audioHits++;
-    if (isVisMatch && isAudMatch && r.vis && r.aud) dualHits++; // counted separately
+    if (isVisMatchTarget && isAudMatchTarget) {
+        dualTotal++;
+        if (userResponse.vis && userResponse.aud) {
+            dualHits++;
+        }
+    } else if (isVisMatchTarget) { // Visual-only match
+        visualTotal++;
+        if (userResponse.vis) {
+            visualHits++;
+        }
+    } else if (isAudMatchTarget) { // Auditory-only match
+        audioTotal++;
+        if (userResponse.aud) {
+            audioHits++;
+        }
+    }
+    // No need to handle 'no match' cases for totals or hits in this part
   });
 
   const pct = (hits, tot) =>

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -68,8 +68,8 @@ export function generateSequence({ n: N_LEVEL = 2 } = {}) {
   const NUM_SCORABLE_TRIALS = 20;
   const TOTAL_TRIALS = NUM_SCORABLE_TRIALS + N_LEVEL;
   const TARGET_DUAL = 2;
-  const TARGET_VISUAL_ONLY = 2;
-  const TARGET_AUDITORY_ONLY = 2;
+  const TARGET_VISUAL_ONLY = 4;
+  const TARGET_AUDITORY_ONLY = 4;
 
   const sequence = new Array(TOTAL_TRIALS);
 


### PR DESCRIPTION
This commit addresses several issues I identified in the Dual N-Back game:

1.  **Generator Match Counts:**
    - I modified `src/utils/generator.js` to produce 4 visual-only and 4 auditory-only matches per round, increased from the previous 2 each. This aligns with the specified game requirements ("20 scorable trials containing exactly 4 visual-only, 4 auditory-only, and 2 dual matches").

2.  **Evaluator Scoring Logic:**
    - I refactored `src/utils/evaluator.js` to ensure accurate and exclusive scoring for dual, visual-only, and auditory-only matches.
    - Previously, dual matches could contribute to visual/auditory totals and hits. The new logic correctly categorizes each trial type independently.

3.  **ARIA Announcement Consistency:**
    - I updated `src/App.jsx` to provide consistent ARIA announcements for filler trials.
    - The `active-cell-announcer` now voices both position and letter for filler trials, matching the announcement style of scorable trials, improving the experience for screen reader users.