### PR TITLE
Fix audio path with base URL

### DIFF
--- a/src/utils/audio.js
+++ b/src/utils/audio.js
@@ -5,10 +5,10 @@ const audioMap = new Map();
 
 export function preloadAudio() {
   LETTERS.forEach((l) => {
-    const a = new Audio(`/sounds/${l}.mp3`); // -14 LUFS @44.1 kHz provided externally
+    const a = new Audio(`${import.meta.env.BASE_URL}sounds/${l}.mp3`); // -14 LUFS @44.1 kHz provided externally
     a.preload = 'auto';
     a.addEventListener('error', () => {
-      console.warn(`Missing audio file: /sounds/${l}.mp3`);
+      console.warn(`Missing audio file: ${import.meta.env.BASE_URL}sounds/${l}.mp3`);
     });
     audioMap.set(l, a);
   });


### PR DESCRIPTION
## Summary
- use `import.meta.env.BASE_URL` when loading sound files

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853d42e5a20832a8c6cf45f956a8937