### PR TITLE
Enhance grid size and show N‑back level

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -198,7 +198,10 @@ export default function App() {
   const currentScorableTrialNum = Math.max(0, currentSequenceIndex - FILLERS + 1);
 
   return (
-    <main className="flex flex-col items-center justify-center min-h-screen p-4">
+    <main className="relative flex flex-col items-center justify-center min-h-screen p-4">
+      <div className="absolute top-4 right-4 text-sm text-gray-600 font-medium">
+        {N}-Back
+      </div>
       <div id="active-cell-announcer" className="visually-hidden" role="status" aria-live="polite"></div>
       <div id="game-state-announcer" className="visually-hidden" role="status" aria-live="assertive"></div>
 

--- a/src/components/Grid.jsx
+++ b/src/components/Grid.jsx
@@ -16,7 +16,7 @@ export default function Grid({ active, showCorrectFlash, showIncorrectFlash }) {
   // active is index 0‑7 or null
   return (
     <div
-      className={`grid grid-cols-3 grid-rows-3 gap-1 w-56 h-56 select-none border border-gray-400 ${
+      className={`grid grid-cols-3 grid-rows-3 gap-1 w-56 h-56 sm:w-72 sm:h-72 lg:w-96 lg:h-96 select-none border border-gray-400 ${
         showCorrectFlash ? 'flash-correct' : ''
       } ${
         showIncorrectFlash ? 'flash-incorrect' : ''


### PR DESCRIPTION
## Summary
- enlarge the grid with responsive Tailwind classes so it's larger on desktop
- display the current N-back level in the top-right corner

## Testing
- `npm install`
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6853d654aaa8832a863dccfb9daaf787