### PR TITLE
Add stats tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "dual-n-back",
       "version": "0.0.0",
       "dependencies": {
+        "chart.js": "^4.5.0",
         "react": "^18.2.0",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
@@ -3802,6 +3804,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.9",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.9.tgz",
@@ -5409,6 +5417,18 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chownr": {
@@ -11100,6 +11120,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "test": "jest"
   },
   "dependencies": {
+    "chart.js": "^4.5.0",
     "react": "^18.2.0",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {

--- a/src/components/Stats.jsx
+++ b/src/components/Stats.jsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend);
+
+export default function Stats({ onBack }) {
+  const [history, setHistory] = useState([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('dnb-history');
+    if (stored) {
+      try {
+        setHistory(JSON.parse(stored));
+      } catch {
+        setHistory([]);
+      }
+    }
+  }, []);
+
+  const labels = history.map((h) => new Date(h.date).toLocaleDateString());
+  const data = {
+    labels,
+    datasets: [
+      {
+        label: 'N-Back Level',
+        data: history.map((h) => h.level),
+        borderColor: 'rgb(99, 102, 241)',
+        backgroundColor: 'rgba(99, 102, 241, 0.5)',
+        yAxisID: 'y',
+      },
+      {
+        label: 'Accuracy %',
+        data: history.map((h) => h.accuracy),
+        borderColor: 'rgb(34, 197, 94)',
+        backgroundColor: 'rgba(34, 197, 94, 0.5)',
+        yAxisID: 'y1',
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    interaction: { mode: 'index', intersect: false },
+    stacked: false,
+    scales: {
+      y: {
+        type: 'linear',
+        position: 'left',
+        ticks: { stepSize: 1 },
+        title: { display: true, text: 'Level' },
+      },
+      y1: {
+        type: 'linear',
+        position: 'right',
+        grid: { drawOnChartArea: false },
+        min: 0,
+        max: 100,
+        title: { display: true, text: 'Accuracy (%)' },
+      },
+    },
+  };
+
+  return (
+    <div className="max-w-lg mx-auto p-4">
+      <h2 className="text-xl mb-4 text-center">Your Progress</h2>
+      {history.length === 0 ? (
+        <p className="text-center mb-4">No data yet.</p>
+      ) : (
+        <Line data={data} options={options} />
+      )}
+      <div className="mt-4 text-center">
+        <button className="px-4 py-2 rounded-lg border shadow" onClick={onBack}>
+          Back
+        </button>
+      </div>
+    </div>
+  );
+}
+
+Stats.propTypes = {
+  onBack: PropTypes.func.isRequired,
+};


### PR DESCRIPTION
## Summary
- generate a user id and save to localStorage
- store game results in localStorage and persist across games
- add Stats component using chart.js to visualize progress
- show Stats button and page in main app
- add chart.js and react-chartjs-2 dependencies

## Testing
- `npm test`
- `npm run lint` *(fails: 'test'/'expect' not defined, unescaped entities)*

------
https://chatgpt.com/codex/tasks/task_e_6853e1810e04832a8fdb523bfbc21b14