### PR TITLE
Add settings panel

### DIFF
--- a/__tests__/Grid.test.jsx
+++ b/__tests__/Grid.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-env jest */
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import Grid from '../src/components/Grid.jsx';

--- a/__tests__/evaluator.test.js
+++ b/__tests__/evaluator.test.js
@@ -1,3 +1,4 @@
+/* eslint-env jest */
 import { evaluateResponses } from '../src/utils/evaluator.js';
 
 describe('evaluateResponses', () => {

--- a/__tests__/keyboard.test.jsx
+++ b/__tests__/keyboard.test.jsx
@@ -1,3 +1,4 @@
+/* eslint-env jest */
 import React, { useEffect, useState } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/__tests__/sequenceCounts.test.js
+++ b/__tests__/sequenceCounts.test.js
@@ -1,3 +1,4 @@
+/* eslint-env jest */
 import { generateSequence } from '../src/utils/generator.js';
 
 test('generator yields correct match counts', () => {

--- a/src/components/ControlButtons.jsx
+++ b/src/components/ControlButtons.jsx
@@ -1,25 +1,29 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export default function ControlButtons({ onVis, onAud, disabled }) {
+export default function ControlButtons({ onVis, onAud, disabled, taskType }) {
   return (
     <div className="flex gap-4 mt-4" role="group" aria-label="response buttons">
-      <button
-        onClick={onVis}
-        disabled={disabled}
-        className="px-4 py-2 rounded-lg border shadow disabled:opacity-40"
-        aria-label="visual match button"
-      >
-        Visual (F)
-      </button>
-      <button
-        onClick={onAud}
-        disabled={disabled}
-        className="px-4 py-2 rounded-lg border shadow disabled:opacity-40"
-        aria-label="auditory match button"
-      >
-        Audio (L)
-      </button>
+      {taskType !== 'audio' && (
+        <button
+          onClick={onVis}
+          disabled={disabled}
+          className="px-4 py-2 rounded-lg border shadow disabled:opacity-40"
+          aria-label="visual match button"
+        >
+          Visual (F)
+        </button>
+      )}
+      {taskType !== 'position' && (
+        <button
+          onClick={onAud}
+          disabled={disabled}
+          className="px-4 py-2 rounded-lg border shadow disabled:opacity-40"
+          aria-label="auditory match button"
+        >
+          Audio (L)
+        </button>
+      )}
     </div>
   );
 }
@@ -28,8 +32,10 @@ ControlButtons.propTypes = {
   onVis: PropTypes.func.isRequired,
   onAud: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
+  taskType: PropTypes.oneOf(['dual', 'position', 'audio']),
 };
 
 ControlButtons.defaultProps = {
   disabled: false,
+  taskType: 'dual',
 };

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function SettingsPanel({ settings, onChange, onClose }) {
+  const handleNumberChange = (e) => {
+    onChange({ ...settings, [e.target.name]: Number(e.target.value) });
+  };
+
+  const handleSelectChange = (e) => {
+    onChange({ ...settings, task: e.target.value });
+  };
+
+  return (
+    <div className="p-4 space-y-3 max-w-sm">
+      <h2 className="text-xl mb-2">Settings</h2>
+      <label className="block">
+        <span className="mr-2">Starting N-Back Level:</span>
+        <input
+          type="number"
+          name="n"
+          min="1"
+          max="10"
+          value={settings.n}
+          onChange={handleNumberChange}
+          className="border p-1 rounded w-16"
+        />
+      </label>
+      <label className="block">
+        <span className="mr-2">Time Between Stimuli (s):</span>
+        <input
+          type="number"
+          name="interval"
+          min="1"
+          max="5"
+          step="0.5"
+          value={settings.interval}
+          onChange={handleNumberChange}
+          className="border p-1 rounded w-16"
+        />
+      </label>
+      <label className="block">
+        <span className="mr-2">Task Type:</span>
+        <select
+          name="task"
+          value={settings.task}
+          onChange={handleSelectChange}
+          className="border p-1 rounded"
+        >
+          <option value="dual">Dual</option>
+          <option value="position">Position Only</option>
+          <option value="audio">Audio Only</option>
+        </select>
+      </label>
+      <button className="mt-4 px-4 py-2 rounded-lg border shadow" onClick={onClose}>
+        Close
+      </button>
+    </div>
+  );
+}
+
+SettingsPanel.propTypes = {
+  settings: PropTypes.shape({
+    n: PropTypes.number.isRequired,
+    interval: PropTypes.number.isRequired,
+    task: PropTypes.string.isRequired,
+  }).isRequired,
+  onChange: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+};


### PR DESCRIPTION
## Summary
- add SettingsPanel component for configuring N-back level, interval, and task type
- support task settings in App and ControlButtons
- update tests with eslint env comments

## Testing
- `npm test`
- `npm run lint` *(fails: no-undef errors in test files)*

------
https://chatgpt.com/codex/tasks/task_e_6853e35dcb18832a848da6b42fc36820