### PR TITLE
Modernize game UI

### DIFF
--- a/__tests__/Grid.test.jsx
+++ b/__tests__/Grid.test.jsx
@@ -13,5 +13,5 @@ test('renders nine cells and highlights active', () => {
   expect(container.firstChild.childNodes).toHaveLength(9);
   const cells = screen.getAllByRole('gridcell');
   const active = cells[2];
-  expect(active).toHaveClass('bg-blue-400');
+  expect(active).toHaveClass('bg-blue-500');
 });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -246,35 +246,38 @@ export default function App() {
   const currentScorableTrialNum = Math.max(0, currentSequenceIndex - FILLERS + 1);
 
   return (
-    <main className="relative flex flex-col items-center justify-center min-h-screen p-4">
-      <div className="absolute top-4 left-4 space-x-4">
-        <button className="text-sm underline" onClick={() => setGameState('stats')}>Stats</button>
-        <button className="text-sm underline" onClick={() => setGameState('settings')}>Settings</button>
-      </div>
-      <div className="absolute top-4 right-4 text-sm text-gray-600 font-medium">
-        {N}-Back
-      </div>
+    <main className="min-h-screen flex flex-col items-center justify-center p-4">
+      <header className="w-full max-w-3xl flex justify-between items-center mb-6">
+        <div className="flex space-x-4 text-sm">
+          <button className="underline" onClick={() => setGameState('stats')}>Stats</button>
+          <button className="underline" onClick={() => setGameState('settings')}>Settings</button>
+        </div>
+        <div className="text-sm font-semibold text-gray-700">{N}-Back</div>
+      </header>
       <div id="active-cell-announcer" className="visually-hidden" role="status" aria-live="polite"></div>
       <div id="game-state-announcer" className="visually-hidden" role="status" aria-live="assertive"></div>
 
       {gameState === 'intro' && (
-        <>
-          <h1 className="text-2xl mb-4">Dual N-Back</h1>
-          <p className="mb-4 text-center" style={{ maxWidth: '400px' }}>
+        <div className="flex flex-col items-center text-center space-y-4">
+          <h1 className="text-3xl font-semibold">Dual N-Back</h1>
+          <p className="max-w-md text-gray-700">
             The goal is to match the visual position and the auditory letter from {N} trials ago.
             <br />
             Press 'F' if the current position matches the position from {N} trials back.
             <br />
             Press 'L' if the current letter matches the letter from {N} trials back.
           </p>
-          <button className="px-6 py-3 rounded-lg border shadow" onClick={startGame}>
+          <button
+            className="px-6 py-3 rounded-lg bg-blue-500 text-white hover:bg-blue-600"
+            onClick={startGame}
+          >
             Start Game
           </button>
-        </>
+        </div>
       )}
 
       {gameState === 'playing' && sequence[currentSequenceIndex] && (
-        <>
+        <div className="flex flex-col items-center space-y-4">
           <Grid
             active={settings.task === 'audio' ? null : sequence[currentSequenceIndex].position}
             showCorrectFlash={showCorrectFlash}
@@ -289,39 +292,43 @@ export default function App() {
             audState={buttonHighlight.aud}
           />
           <StatusBar
-            trial={currentScorableTrialNum > NUM_SCORABLE_TRIALS ? NUM_SCORABLE_TRIALS : currentScorableTrialNum}
+            trial={
+              currentScorableTrialNum > NUM_SCORABLE_TRIALS
+                ? NUM_SCORABLE_TRIALS
+                : currentScorableTrialNum
+            }
             total={NUM_SCORABLE_TRIALS}
           />
-        </>
+        </div>
       )}
 
       {gameState === 'break' && (
-        <>
-          <p className="mb-4">Round complete.</p>
+        <div className="flex flex-col items-center space-y-4">
+          <p>Round complete.</p>
           <button
-            className="px-4 py-2 rounded-lg border shadow"
+            className="px-4 py-2 rounded-lg bg-blue-500 text-white hover:bg-blue-600"
             onClick={handleContinueFromBreak}
           >
             Continue
           </button>
-        </>
+        </div>
       )}
 
       {gameState === 'complete' && results && (
-        <>
-          <h2 className="text-xl mb-4">Results</h2>
+        <div className="flex flex-col items-center space-y-4">
+          <h2 className="text-xl">Results</h2>
           <div className="space-y-2">
             <ResultRow label="Visual" data={results.visual} />
             <ResultRow label="Auditory" data={results.auditory} />
             <ResultRow label="Dual" data={results.dual} />
           </div>
           <button
-            className="mt-6 px-4 py-2 rounded-lg border shadow"
+            className="mt-4 px-4 py-2 rounded-lg bg-blue-500 text-white hover:bg-blue-600"
             onClick={handlePlayAgain}
           >
             Play Again
           </button>
-        </>
+        </div>
       )}
 
       {gameState === 'stats' && <Stats onBack={() => setGameState('intro')} />}

--- a/src/components/ControlButtons.jsx
+++ b/src/components/ControlButtons.jsx
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 
 export default function ControlButtons({ onVis, onAud, disabled, taskType, visState, audState }) {
   const getHighlight = (state) => {
-    if (state === 'correct') return 'bg-green-300';
-    if (state === 'incorrect') return 'bg-red-300';
-    if (state === 'miss') return 'bg-yellow-300';
+    if (state === 'correct') return 'bg-green-500 text-white';
+    if (state === 'incorrect') return 'bg-red-500 text-white';
+    if (state === 'miss') return 'bg-yellow-400 text-white';
     return '';
   };
   return (
@@ -14,7 +14,7 @@ export default function ControlButtons({ onVis, onAud, disabled, taskType, visSt
         <button
           onClick={onVis}
           disabled={disabled}
-          className={`px-4 py-2 rounded-lg border shadow disabled:opacity-40 ${getHighlight(visState)}`}
+          className={`px-4 py-2 rounded-lg border shadow disabled:opacity-40 bg-blue-500 text-white hover:bg-blue-600 ${getHighlight(visState)}`}
           aria-label="visual match button"
         >
           Visual (F)
@@ -24,7 +24,7 @@ export default function ControlButtons({ onVis, onAud, disabled, taskType, visSt
         <button
           onClick={onAud}
           disabled={disabled}
-          className={`px-4 py-2 rounded-lg border shadow disabled:opacity-40 ${getHighlight(audState)}`}
+          className={`px-4 py-2 rounded-lg border shadow disabled:opacity-40 bg-blue-500 text-white hover:bg-blue-600 ${getHighlight(audState)}`}
           aria-label="auditory match button"
         >
           Audio (L)

--- a/src/components/Grid.jsx
+++ b/src/components/Grid.jsx
@@ -16,7 +16,7 @@ export default function Grid({ active, showCorrectFlash, showIncorrectFlash }) {
   // active is index 0‑7 or null
   return (
     <div
-      className={`grid grid-cols-3 grid-rows-3 gap-1 w-56 h-56 sm:w-72 sm:h-72 lg:w-96 lg:h-96 select-none border border-gray-400 ${
+      className={`grid grid-cols-3 grid-rows-3 gap-1 w-56 h-56 sm:w-72 sm:h-72 lg:w-96 lg:h-96 select-none border border-gray-300 ${
         showCorrectFlash ? 'flash-correct' : ''
       } ${
         showIncorrectFlash ? 'flash-incorrect' : ''
@@ -38,7 +38,7 @@ export default function Grid({ active, showCorrectFlash, showIncorrectFlash }) {
             aria-label={`row ${r} column ${c}`}
             aria-selected={isActive}
             className={`rounded-lg border aspect-square w-full h-full flex items-center justify-center transition-all duration-300 ${
-              isActive ? 'bg-blue-400' : 'bg-gray-200'
+              isActive ? 'bg-blue-500' : 'bg-gray-100'
             } ${showCorrectFlash && isActive ? 'ring-4 ring-yellow-400' : ''}`}
           />
         );

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -51,7 +51,7 @@ export default function SettingsPanel({ settings, onChange, onClose }) {
           <option value="audio">Audio Only</option>
         </select>
       </label>
-      <button className="mt-4 px-4 py-2 rounded-lg border shadow" onClick={onClose}>
+      <button className="mt-4 px-4 py-2 rounded-lg bg-blue-500 text-white hover:bg-blue-600" onClick={onClose}>
         Close
       </button>
     </div>

--- a/src/components/Stats.jsx
+++ b/src/components/Stats.jsx
@@ -80,7 +80,7 @@ export default function Stats({ onBack }) {
         <Line data={data} options={options} />
       )}
       <div className="mt-4 text-center">
-        <button className="px-4 py-2 rounded-lg border shadow" onClick={onBack}>
+        <button className="px-4 py-2 rounded-lg bg-blue-500 text-white hover:bg-blue-600" onClick={onBack}>
           Back
         </button>
       </div>

--- a/src/components/StatusBar.jsx
+++ b/src/components/StatusBar.jsx
@@ -2,9 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 export default function StatusBar({ trial, total }) {
+  const pct = Math.min(100, Math.round((trial / total) * 100));
   return (
-    <div className="mt-4" role="status" aria-live="polite" id="trial-counter-description">
-      Trial {trial}/{total}
+    <div className="w-full max-w-xs mt-4" role="status" aria-live="polite" id="trial-counter-description">
+      <div className="h-2 bg-gray-200 rounded">
+        <div className="h-full bg-blue-500 rounded" style={{ width: `${pct}%` }} />
+      </div>
+      <p className="text-center text-sm mt-2">Trial {trial}/{total}</p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- modern layout with centered game board and header
- update button and grid styles
- add progress bar in StatusBar
- tweak stats and settings buttons
- adjust tests for new styles

## Testing
- `npm run lint` *(fails: cannot find package 'globals' and various lint errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853e7380c1c832a84a7c3b46ab7f2d9