### PR TITLE
Add A/L keyboard shortcuts

### DIFF
--- a/__tests__/keyboard.test.jsx
+++ b/__tests__/keyboard.test.jsx
@@ -9,7 +9,7 @@ function HitCounter() {
   useEffect(() => {
     const handler = (e) => {
       const key = e.key.toLowerCase();
-      if (key === 'f') setVis((v) => v + 1);
+      if (key === 'a') setVis((v) => v + 1);
       if (key === 'l') setAud((a) => a + 1);
     };
     document.addEventListener('keydown', handler);
@@ -23,10 +23,10 @@ function HitCounter() {
   );
 }
 
-test('F and L key presses increment counters', async () => {
+test('A and L key presses increment counters', async () => {
   const user = userEvent.setup();
   render(<HitCounter />);
-  await user.keyboard('f');
+  await user.keyboard('a');
   await user.keyboard('l');
   expect(screen.getByTestId('vis').textContent).toBe('1');
   expect(screen.getByTestId('aud').textContent).toBe('1');

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -76,12 +76,12 @@ export default function App() {
   };
 
   // ----- One time setup -----
-  // Preload audio assets and register global key handlers for F/L shortcuts.
+  // Preload audio assets and register global key handlers for A/L shortcuts.
   useEffect(() => {
     preloadAudio();
     const keyHandler = (e) => {
       const key = e.key.toLowerCase();
-      if (key === 'f') handleResponse('vis');
+      if (key === 'a') handleResponse('vis');
       if (key === 'l') handleResponse('aud');
     };
     document.addEventListener('keydown', keyHandler);
@@ -307,7 +307,7 @@ export default function App() {
           <p className="max-w-md text-gray-700">
             The goal is to match the visual position and the auditory letter from {N} trials ago.
             <br />
-            Press 'F' if the current position matches the position from {N} trials back.
+            Press 'A' if the current position matches the position from {N} trials back.
             <br />
             Press 'L' if the current letter matches the letter from {N} trials back.
           </p>

--- a/src/components/ControlButtons.jsx
+++ b/src/components/ControlButtons.jsx
@@ -26,7 +26,7 @@ export default function ControlButtons({ onVis, onAud, disabled, taskType, visSt
           className={`px-4 py-2 rounded-lg border shadow disabled:opacity-40 bg-blue-500 text-white hover:bg-blue-600 ${getHighlight(visState)}`}
           aria-label="visual match button"
         >
-          Visual (F)
+          Position (A)
         </button>
       )}
       {taskType !== 'position' && (


### PR DESCRIPTION
## Summary
- switch position match key from **F** to **A**
- adjust introduction text to mention the new shortcut
- update ControlButtons to show `Position (A)` instead of `Visual (F)`
- tweak keyboard shortcut test for new keys

## Testing
- `npx jest` *(fails: needs package installation)*

------
https://chatgpt.com/codex/tasks/task_e_6853eb6e0f24832a813a0be59861fe5e