### PR TITLE
Switch UI to light theme

### DIFF
--- a/__tests__/Grid.test.jsx
+++ b/__tests__/Grid.test.jsx
@@ -13,5 +13,5 @@ test('renders nine cells and highlights active', () => {
   expect(container.firstChild.childNodes).toHaveLength(9);
   const cells = screen.getAllByRole('gridcell');
   const active = cells[2];
-  expect(active).toHaveClass('bg-blue-500');
+  expect(active).toHaveClass('bg-blue-600');
 });

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Dual N‑Back Game</title>
   </head>
-  <body class="bg-gray-100 text-gray-900 selection:bg-yellow-200">
+  <body class="bg-white text-gray-900 font-sans selection:bg-yellow-200">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -351,7 +351,7 @@ export default function App() {
   const currentScorableTrialNum = Math.max(0, currentSequenceIndex - FILLERS + 1);
 
   return (
-    <main className="min-h-screen flex flex-col items-center justify-center p-4">
+    <main className="min-h-screen flex flex-col items-center justify-center p-4 bg-white text-gray-900 font-sans">
       {!focusMode && (
         <header className="w-full max-w-3xl flex justify-between items-center mb-6">
           <div className="flex space-x-4 text-sm">
@@ -476,7 +476,7 @@ export default function App() {
         <div className="flex flex-col items-center space-y-4">
           <p>Round complete.</p>
           <button
-            className="px-4 py-2 rounded-lg bg-blue-500 text-white hover:bg-blue-600"
+            className="px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors duration-150"
             onClick={handleContinueFromBreak}
           >
             Continue
@@ -496,7 +496,7 @@ export default function App() {
           </div>
           <div className="flex gap-2 mt-4">
             <button
-              className="px-4 py-2 rounded-lg bg-blue-500 text-white hover:bg-blue-600"
+              className="px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors duration-150"
               onClick={handlePlayAgain}
             >
               Play Again

--- a/src/components/ControlButtons.jsx
+++ b/src/components/ControlButtons.jsx
@@ -23,7 +23,7 @@ export default function ControlButtons({ onVis, onAud, disabled, taskType, visSt
         <button
           onClick={onVis}
           disabled={disabled}
-          className={`px-4 py-2 rounded-lg border shadow disabled:opacity-40 bg-blue-500 text-white hover:bg-blue-600 ${getHighlight(visState)}`}
+          className={`px-4 py-2 rounded-lg border shadow disabled:opacity-40 bg-blue-600 text-white hover:bg-blue-700 transition-colors duration-150 ${getHighlight(visState)}`}
           aria-label="visual match button"
         >
           Position (A)
@@ -33,7 +33,7 @@ export default function ControlButtons({ onVis, onAud, disabled, taskType, visSt
         <button
           onClick={onAud}
           disabled={disabled}
-          className={`px-4 py-2 rounded-lg border shadow disabled:opacity-40 bg-blue-500 text-white hover:bg-blue-600 ${getHighlight(audState)}`}
+          className={`px-4 py-2 rounded-lg border shadow disabled:opacity-40 bg-blue-600 text-white hover:bg-blue-700 transition-colors duration-150 ${getHighlight(audState)}`}
           aria-label="auditory match button"
         >
           Audio (L)

--- a/src/components/Grid.jsx
+++ b/src/components/Grid.jsx
@@ -25,7 +25,7 @@ export default function Grid({ active, showCorrectFlash, showIncorrectFlash }) {
   // no cell should be lit.
   return (
     <div
-      className={`grid grid-cols-3 grid-rows-3 gap-1 w-56 h-56 sm:w-72 sm:h-72 lg:w-96 lg:h-96 select-none border border-gray-300 ${
+      className={`grid grid-cols-3 grid-rows-3 gap-1 w-56 h-56 sm:w-72 sm:h-72 lg:w-96 lg:h-96 select-none border border-gray-400 ${
         showCorrectFlash ? 'flash-correct' : ''
       } ${
         showIncorrectFlash ? 'flash-incorrect' : ''
@@ -50,7 +50,7 @@ export default function Grid({ active, showCorrectFlash, showIncorrectFlash }) {
             aria-label={`row ${r} column ${c}`}
             aria-selected={isActive}
             className={`rounded-lg border aspect-square w-full h-full flex items-center justify-center transition-all duration-300 ${
-              isActive ? 'bg-blue-500' : 'bg-gray-100'
+              isActive ? 'bg-blue-600' : 'bg-gray-100'
             } ${showCorrectFlash && isActive ? 'ring-4 ring-yellow-400' : ''}`}
           />
         );

--- a/src/components/SettingsPanel.jsx
+++ b/src/components/SettingsPanel.jsx
@@ -59,7 +59,7 @@ export default function SettingsPanel({ settings, onChange, onClose }) {
           <option value="audio">Audio Only</option>
         </select>
       </label>
-      <button className="mt-4 px-4 py-2 rounded-lg bg-blue-500 text-white hover:bg-blue-600" onClick={onClose}>
+      <button className="mt-4 px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors duration-150" onClick={onClose}>
         Close
       </button>
     </div>

--- a/src/components/Stats.jsx
+++ b/src/components/Stats.jsx
@@ -87,7 +87,7 @@ export default function Stats({ onBack }) {
         <Line data={data} options={options} />
       )}
       <div className="mt-4 text-center">
-        <button className="px-4 py-2 rounded-lg bg-blue-500 text-white hover:bg-blue-600" onClick={onBack}>
+        <button className="px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors duration-150" onClick={onBack}>
           Back
         </button>
       </div>

--- a/src/components/StatusBar.jsx
+++ b/src/components/StatusBar.jsx
@@ -13,7 +13,7 @@ export default function StatusBar({ trial, total }) {
   return (
     <div className="w-full max-w-xs mt-4" role="status" aria-live="polite" id="trial-counter-description">
       <div className="h-2 bg-gray-200 rounded">
-        <div className="h-full bg-blue-500 rounded" style={{ width: `${pct}%` }} />
+        <div className="h-full bg-blue-600 rounded" style={{ width: `${pct}%` }} />
       </div>
       <p className="text-center text-sm mt-2">Trial {trial}/{total}</p>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -15,11 +15,11 @@
 }
 
 .flash-correct {
-  background-color: #9AE6B4; /* A light green, adjust as needed */
-  /* Add transition if desired, but for a quick flash, direct change is often fine */
+  background-color: rgba(16, 185, 129, 0.3); /* teal-400 with opacity */
 }
 
 .flash-incorrect {
+  background-color: rgba(239, 68, 68, 0.3); /* red-500 with opacity */
   animation: incorrect-flash-animation 0.3s ease-out;
 }
 


### PR DESCRIPTION
## Summary
- set body default to white background and sans font
- adjust main container to use light theme
- update button colours to blue-600/700 with transitions
- soften grid borders and use blue-600 for active cell
- tweak progress bar colour
- revise flash feedback styles for light theme
- update tests for new styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855296cc350832abe0a7fac10bab111